### PR TITLE
Specified V8 5.9-lkgr version

### DIFF
--- a/PHPJS/installation.md
+++ b/PHPJS/installation.md
@@ -70,7 +70,7 @@ export PATH=`pwd`/depot_tools:"$PATH"
 gclient
 fetch v8
 cd v8
-git checkout lkgr
+git checkout 5.9-lkgr
 gclient sync
 gn gen out.gn/library --args='is_debug=false is_component_build=true v8_enable_i18n_support=false'
 ninja -C out.gn/library libv8.so


### PR DESCRIPTION
It is specified in the in-depth documentation that the branch used should be a 5.x-lkgr.

Followed this page and ended up with a non-working `platform.h` since `ExpectedRuntime` got deprecated.